### PR TITLE
Using OpenCV Mat to fix memory leak and increase speed

### DIFF
--- a/arapaho/arapaho.hpp
+++ b/arapaho/arapaho.hpp
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <string>
+#include <opencv2/opencv.hpp>
 #include "network.h"
 #include "detection_layer.h"
 #include "cost_layer.h"
@@ -47,13 +48,6 @@
 		float nms;
 		int maxClasses;
 	};
-	struct ArapahoV2ImageBuff
-	{
-		unsigned char* bgr;
-		int w;
-		int h;
-		int channels;
-	};
 
 	//////////////////////////////////////////////////////////////////////////
 
@@ -68,7 +62,7 @@
 			int & expectedHeight);
 
 		bool Detect(
-			ArapahoV2ImageBuff & imageBuff,
+			const cv::Mat & inputMat,
 			float thresh,
 			float hier_thresh,
 			int & objectCount);

--- a/arapaho/test.cpp
+++ b/arapaho/test.cpp
@@ -102,7 +102,6 @@ int main()
     //
     
     // Setup image buffer here
-    ArapahoV2ImageBuff arapahoImage;
     Mat image;
 
     // Setup show window
@@ -144,18 +143,13 @@ int main()
             // Remember the time
             auto detectionStartTime = std::chrono::system_clock::now();
 
-            // Process the image
-            arapahoImage.bgr = image.data;
-            arapahoImage.w = image.size().width;
-            arapahoImage.h = image.size().height;
-            arapahoImage.channels = 3;
             // Using expectedW/H, can optimise scaling using HW in platforms where available
             
             int numObjects = 0;
             
             // Detect the objects in the image
             p->Detect(
-                arapahoImage,
+                image,
                 0.24,
                 0.5,
                 numObjects);
@@ -196,10 +190,10 @@ int main()
                 int leftTopX = 0, leftTopY = 0, rightBotX = 0,rightBotY = 0;
                 for (objId = 0; objId < numObjects; objId++)
                 {
-                    leftTopX = 1 + arapahoImage.w*(boxes[objId].x - boxes[objId].w / 2);
-                    leftTopY = 1 + arapahoImage.h*(boxes[objId].y - boxes[objId].h / 2);
-                    rightBotX = 1 + arapahoImage.w*(boxes[objId].x + boxes[objId].w / 2);
-                    rightBotY = 1 + arapahoImage.h*(boxes[objId].y + boxes[objId].h / 2);
+                    leftTopX = 1 + image.cols*(boxes[objId].x - boxes[objId].w / 2);
+                    leftTopY = 1 + image.rows*(boxes[objId].y - boxes[objId].h / 2);
+                    rightBotX = 1 + image.cols*(boxes[objId].x + boxes[objId].w / 2);
+                    rightBotY = 1 + image.rows*(boxes[objId].y + boxes[objId].h / 2);
                     DPRINTF("Box #%d: center {x,y}, box {w,h} = [%f, %f, %f, %f]\n", objId, boxes[objId].x, boxes[objId].y, boxes[objId].w, boxes[objId].h);
                     // Show image and overlay using OpenCV
                     rectangle(image,


### PR DESCRIPTION
Following the discussion in #19, this PR fixes the memory leak from using darknet's make_image() function. This PR changes the image format from ArapahoV2ImageBuff to OpenCV's Mat for a few reasons:

1. OpenCV is already very optimized for handling memory. Memory allocation and deallocation on every frame was slowing down the performance.
1. resize_image() and conversion to float also was slowing down the performance as they were pixel-wise operations. OpenCV is optimized for this also.
1. If later the hardware acceleration is desired, it would be easier to make that switch. (I didn't make the switch in this PR because for distributions not using OpenCV3, it can have backward compatibility issues)

With this PR, I saw ~3x speed increase on a 1920x1080 video and with no more computer freeze happening from memory leaks.