### PR TITLE
Fix for memory leak in Arapaho::Detect function

### DIFF
--- a/arapaho/arapaho.cpp
+++ b/arapaho/arapaho.cpp
@@ -204,7 +204,9 @@ bool ArapahoV2::Detect(
     if (inputImage.h != net.h || inputImage.w != net.w)
     {
         DPRINTF("Detect: Resizing image to match network \n");
-        inputImage = resize_image(inputImage, net.w, net.h);
+        image inputpushImageTemp = resize_image(inputImage, net.w, net.h);
+        free_image(inputImage);
+        inputImage=inputImageTemp;
         if(!inputImage.data || inputImage.w != net.w || 
                 inputImage.h != net.h)
         {
@@ -235,7 +237,7 @@ bool ArapahoV2::Detect(
             objectCount ++;
         }
     }
-
+    free_image(inputImage);
     return true;
 }
     


### PR DESCRIPTION
In Arapaho::Detect() function, memory for inputImage.data had been allocated, but never freed. Also, resize_image() had allocated additional memory for resized image, but original image data hadn not been freed. Because of that, function wasn't usable for detection in video.
Proposed changes fix this issue without general reconstruction of the Arapaho class.