### PR TITLE
Fix macOS compile issues

### DIFF
--- a/arapaho/Makefile
+++ b/arapaho/Makefile
@@ -2,8 +2,62 @@
 # Undefine GPU, CUDNN if darknet was built without these defined. These 2 flags have to match darknet flags.
 # https://github.com/prabindh/darknet
 
-arapaho: clean
-	g++ test.cpp arapaho.cpp -DGPU -DCUDNN -D_DEBUG -I../src/ -I/usr/local/cuda/include/ -L./ -ldarknet-cpp-shared -L/usr/local/lib -lopencv_cudabgsegm -lopencv_cudaobjdetect -lopencv_cudastereo -lopencv_shape -lopencv_stitching -lopencv_cudafeatures2d -lopencv_superres -lopencv_cudacodec -lopencv_videostab -lopencv_cudaoptflow -lopencv_cudalegacy -lopencv_calib3d -lopencv_features2d -lopencv_objdetect -lopencv_highgui -lopencv_videoio -lopencv_photo -lopencv_imgcodecs -lopencv_cudawarping -lopencv_cudaimgproc -lopencv_cudafilters -lopencv_video -lopencv_ml -lopencv_imgproc -lopencv_flann -lopencv_cudaarithm -lopencv_viz -lopencv_core -lopencv_cudev -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand -std=c++11 -o arapaho.out
-	
+GPU=1
+CUDNN=1
+DEBUG=0
+
+CC_CPP=g++
+CFLAGS_CPP=-Wno-write-strings -std=c++11
+
+OPTS=-Ofast
+LDFLAGS= -L./ -ldarknet-cpp-shared
+LDFLAGS+= -Wl,-rpath,'$$ORIGIN'
+LDFLAGS+= `pkg-config --libs opencv`
+COMMON= -I../src/
+COMMON+= `pkg-config --cflags opencv`
+CFLAGS=-Wall -Wfatal-errors
+
+ifeq ($(DEBUG), 1)
+OPTS=-O0 -g
+COMMON+= -D_DEBUG
+CFLAGS+= -D_DEBUG
+endif
+
+CFLAGS+=$(OPTS)
+
+ifeq ($(GPU), 1)
+COMMON+= -DGPU -I/usr/local/cuda/include/
+CFLAGS+= -DGPU
+LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+endif
+
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
+CFLAGS+= -DCUDNN
+LDFLAGS+= -lcudnn
+endif
+
+EXEC_CPP=arapaho
+OBJDIR_CPP=./obj-cpp/
+OBJ=test.o arapaho.o
+OBJS= $(addprefix $(OBJDIR), $(OBJ))
+DEPS= $(wildcard *.hpp) Makefile
+
+OBJS_CPP = $(addprefix $(OBJDIR_CPP), $(OBJ))
+
+all: obj-cpp $(EXEC_CPP)
+
+$(EXEC_CPP): obj-cpp clean $(OBJS_CPP)
+	$(CC_CPP) $(COMMON) $(CFLAGS) $(OBJS_CPP) -o $@ $(LDFLAGS)
+
+$(OBJDIR_CPP)%.o: %.cpp $(DEPS)
+	$(CC_CPP) $(COMMON) $(CFLAGS_CPP) $(CFLAGS) -c $< -o $@
+
+
+obj-cpp:
+	mkdir -p $(OBJDIR_CPP)
+
+.PHONY: clean
+
 clean:
-	rm -rf ./arapaho.out	
+	rm -rf $(OBJS_CPP) $(EXEC_CPP)

--- a/src/art.c
+++ b/src/art.c
@@ -4,7 +4,7 @@
 #include "option_list.h"
 #include "blas.h"
 #include "classifier.h"
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
 #include <sys/time.h>
 #endif
 

--- a/src/classifier.c
+++ b/src/classifier.c
@@ -6,7 +6,7 @@
 #include "assert.h"
 #include "classifier.h"
 #include "cuda.h"
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
 #include <sys/time.h>
 #endif
 

--- a/src/coco.c
+++ b/src/coco.c
@@ -167,7 +167,7 @@ void validate_coco(char *cfgfile, char *weightfile)
 
     int j;
     char buff[1024];
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
     snprintf(buff, 1024, "%s/coco_results.json", base);
 #else
 	_snprintf(buff, 1024, "%s/coco_results.json", base);
@@ -273,7 +273,7 @@ void validate_coco_recall(char *cfgfile, char *weightfile)
     FILE **fps = (FILE**)calloc(classes, sizeof(FILE *));
     for(j = 0; j < classes; ++j){
         char buff[1024];
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s%s.txt", base, coco_classes[j]);
 #else
 		_snprintf(buff, 1024, "%s%s.txt", base, coco_classes[j]);

--- a/src/data.h
+++ b/src/data.h
@@ -1,7 +1,7 @@
 #ifndef DATA_H
 #define DATA_H
 
-#if defined __linux__ || defined PTHREAD_WINDOWS
+#if defined __linux__ || defined __APPLE__ || defined PTHREAD_WINDOWS
 #include <pthread.h>
 #endif
 
@@ -78,7 +78,7 @@ extern "C" {
 
 void free_data(data d);
 
-#if defined __linux__ || defined PTHREAD_WINDOWS
+#if defined __linux__ || defined __APPLE__ || defined PTHREAD_WINDOWS
 pthread_t load_data(load_args args);
 
 pthread_t load_data_in_thread(load_args args);

--- a/src/demo.c
+++ b/src/demo.c
@@ -7,7 +7,7 @@
 #include "box.h"
 #include "image.h"
 #include "demo.h"
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
 #include <sys/time.h>
 #endif
 

--- a/src/detector.c
+++ b/src/detector.c
@@ -284,7 +284,7 @@ void validate_detector_flip(char *datacfg, char *cfgfile, char *weightfile, char
     int imagenet = 0;
     if(0==strcmp(type, "coco")){
         if(!outfile) outfile = "coco_results";
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s/%s.json", prefix, outfile);
 #else
         _snprintf(buff, 1024, "%s/%s.json", prefix, outfile);
@@ -294,7 +294,7 @@ void validate_detector_flip(char *datacfg, char *cfgfile, char *weightfile, char
         coco = 1;
     } else if(0==strcmp(type, "imagenet")){
         if(!outfile) outfile = "imagenet-detection";
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s/%s.txt", prefix, outfile);
 #else
         _snprintf(buff, 1024, "%s/%s.txt", prefix, outfile);
@@ -306,7 +306,7 @@ void validate_detector_flip(char *datacfg, char *cfgfile, char *weightfile, char
         if(!outfile) outfile = "comp4_det_test_";
         fps = (FILE**)calloc(classes, sizeof(FILE *));
         for(j = 0; j < classes; ++j){
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
             snprintf(buff, 1024, "%s/%s%s.txt", prefix, outfile, names[j]);
 #else
             _snprintf(buff, 1024, "%s/%s%s.txt", prefix, outfile, names[j]);
@@ -432,7 +432,7 @@ void validate_detector(char *datacfg, char *cfgfile, char *weightfile, char *out
     int imagenet = 0;
     if(0==strcmp(type, "coco")){
         if(!outfile) outfile = "coco_results";
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s/%s.json", prefix, outfile);
 #else
 		_snprintf(buff, 1024, "%s/%s.json", prefix, outfile);
@@ -442,7 +442,7 @@ void validate_detector(char *datacfg, char *cfgfile, char *weightfile, char *out
         coco = 1;
     } else if(0==strcmp(type, "imagenet")){
         if(!outfile) outfile = "imagenet-detection";
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s/%s.txt", prefix, outfile);
 #else
 		_snprintf(buff, 1024, "%s/%s.txt", prefix, outfile);
@@ -455,7 +455,7 @@ void validate_detector(char *datacfg, char *cfgfile, char *weightfile, char *out
         if(!outfile) outfile = "comp4_det_test_";
         fps = (FILE**)calloc(classes, sizeof(FILE *));
         for(j = 0; j < classes; ++j){
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
             snprintf(buff, 1024, "%s/%s%s.txt", prefix, outfile, names[j]);
 #else
 			_snprintf(buff, 1024, "%s/%s%s.txt", prefix, outfile, names[j]);

--- a/src/go.c
+++ b/src/go.c
@@ -4,7 +4,7 @@
 #include "option_list.h"
 #include "blas.h"
 #include "data.h"
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
 #include <unistd.h>
 #endif
 
@@ -841,7 +841,7 @@ void self_go(char *filename, char *weightfile, char *f2, char *w2, int multi)
             else ++p2;
             ++total;
             fprintf(stderr, "Total: %d, Player 1: %f, Player 2: %f\n", total, (float)p1/total, (float)p2/total);
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
             sleep(1);
 #else
             Sleep(1000);

--- a/src/regressor.c
+++ b/src/regressor.c
@@ -5,7 +5,9 @@
 #include "blas.h"
 #include "assert.h"
 #include "cuda.h"
+#if defined __linux__ || defined __APPLE__
 #include <sys/time.h>
+#endif
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"

--- a/src/yolo.c
+++ b/src/yolo.c
@@ -138,7 +138,7 @@ void validate_yolo(char *cfgfile, char *weightfile)
     FILE **fps = (FILE**)calloc(classes, sizeof(FILE *));
     for(j = 0; j < classes; ++j){
         char buff[1024];
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s%s.txt", base, voc_names[j]);
 #else
 		_snprintf(buff, 1024, "%s%s.txt", base, voc_names[j]);
@@ -240,7 +240,7 @@ void validate_yolo_recall(char *cfgfile, char *weightfile)
     FILE **fps = (FILE**)calloc(classes, sizeof(FILE *));
     for(j = 0; j < classes; ++j){
         char buff[1024];
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
         snprintf(buff, 1024, "%s%s.txt", base, voc_names[j]);
 #else        
         _snprintf(buff, 1024, "%s%s.txt", base, voc_names[j]);


### PR DESCRIPTION
Builds on macOS Sierra (10.12) failed for me with the following error message. My changes resolve the build issue and enhance the arapaho Makefile. 

```
./src/data.c:12:1: fatal error: unknown type name 'pthread_mutex_t'; did you
      mean 'pthread_attr_t'?
pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
^~~~~~~~~~~~~~~
pthread_attr_t
/usr/include/sys/_pthread/_pthread_attr_t.h:30:33: note: 'pthread_attr_t'
      declared here
typedef __darwin_pthread_attr_t pthread_attr_t;
                                ^
1 error generated.
make: *** [obj-cpp/data.o] Error 1
```