### PR TITLE
macOS cpp build fixes

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -35,7 +35,10 @@ extern int gpu_index;
 #endif
 
 #if defined(__APPLE__)
-#define _snprintf snprintf
+    #include <AvailabilityMacros.h>
+    #ifdef MAC_OS_X_VERSION_10_12
+        #define _snprintf snprintf
+    #endif
 #endif
 
 #ifdef __cplusplus 

--- a/include/darknet.h
+++ b/include/darknet.h
@@ -34,7 +34,9 @@ extern int gpu_index;
     #include <opencv2/opencv.hpp>    
 #endif
 
-
+#if defined(__APPLE__)
+#define _snprintf snprintf
+#endif
 
 #ifdef __cplusplus 
 extern "C" {

--- a/src/data.c
+++ b/src/data.c
@@ -355,7 +355,7 @@ box bound_image(image im)
             }
         }
     }
-    box b = {minx, miny, maxx-minx + 1.0f, maxy-miny + 1.0f};
+    box b = {static_cast<float>(minx), static_cast<float>(miny), maxx-minx + 1.0f, maxy-miny + 1.0f};
     //printf("%f %f %f %f\n", b.x, b.y, b.w, b.h);
     return b;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -67,7 +67,11 @@ int clock_gettime(int dummy, struct timespec *ct)
 double what_time_is_it_now()
 {
     struct timespec now;
+#if defined(CLOCK_MONOTONIC)
+    clock_gettime(CLOCK_MONOTONIC, &now);
+#else
     clock_gettime(0, &now);
+#endif
     return now.tv_sec + now.tv_nsec*1e-9;
 }
 


### PR DESCRIPTION
- [x] Fix: `what_time_is_it_now` to use `CLOCK_MONOTONIC` when defined (macOS 10.12+) 
Apple introduced their own version of `clock_gettime` in 10.12 and didn't keep 1st argument as int
```
./src/utils.c:70:5: fatal error: no matching function for call to 'clock_gettime'
    clock_gettime(0, &now);
    ^~~~~~~~~~~~~
/usr/include/time.h:177:5: note: candidate function not viable: no known conversion from 'int' to 'clockid_t' for 1st argument
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
1 error generated.
```
- [x] Fix: compile error for bound_image because of implicit conversion from `int` to `float`
```
./src/data.c:358:14: fatal error: non-constant-expression cannot be narrowed from type 'int' to 'float' in initializer list [-Wc++11-narrowing]
    box b = {minx, miny, maxx-minx + 1.0f, maxy-miny + 1.0f};
             ^~~~
./src/data.c:358:14: note: insert an explicit cast to silence this issue
    box b = {minx, miny, maxx-minx + 1.0f, maxy-miny + 1.0f};
             ^~~~
             static_cast<float>( )
1 error generated.
```
- [x] Fix: `_snprintf` is not defined when `__APPLE__`. Defined `_snprintf` as `snprintf`
Instead of going around and changing the `#ifdef __linux__ \n snprintf ...`, added definition that would define `_snprintf` as `snprintf` when compiling on `macOS`
```
/src/cuda.c:42:2: fatal error: use of undeclared identifier '_snprintf'; did you mean 'vsnprintf'?
        _snprintf(buffer, 256, "CUDA Error: %s", s);
        ^~~~~~~~~
        vsnprintf
/usr/include/stdio.h:341:6: note: 'vsnprintf' declared here
int      vsnprintf(char * __restrict __str, size_t __size, const char * __restrict __format, va_list) __printflike(3, 0);
         ^
```