### PR TITLE
Fix confusion between hier threshold and threshold.

### DIFF
--- a/arapaho/arapaho.cpp
+++ b/arapaho/arapaho.cpp
@@ -295,7 +295,7 @@ void ArapahoV2::__Detect(float* inData, float thresh, float hier_thresh, int & o
     network_predict(net, inData);
     
     nboxes = 0;
-    dets = get_network_boxes(net, 1, 1, hier_thresh, 0, 0, 0, &nboxes);
+    dets = get_network_boxes(net, 1, 1, thresh, 0, 0, 0, &nboxes);
     if(nms)
     {
         do_nms_sort(dets, nboxes, l.classes, 0.5);


### PR DESCRIPTION
According network.h, threshold then hier is used:

> detection *get_network_boxes(network *net, int w, int h, float thresh, float hier, int *map, int relative, int *num);

Fix done into "_void ArapahoV2::__Detect(float* inData, float thresh, float hier_thresh, int & objectCount)_"



